### PR TITLE
Moving JSON serialization code to dedicated libraries

### DIFF
--- a/ExtendableEnums.Microsoft.AspNetCore.UnitTests/ModelBindingTests.cs
+++ b/ExtendableEnums.Microsoft.AspNetCore.UnitTests/ModelBindingTests.cs
@@ -13,6 +13,19 @@ public class ModelBindingTests : IDisposable
 
     private bool hasDisposed;
 
+    private JsonSerializerSettings options = new();
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        var options = new JsonSerializerSettings
+        {
+            Formatting = Formatting.Indented
+        };
+        options.Converters.AddExtendableEnums();
+        this.options = options;
+    }
+
     ~ModelBindingTests()
     {
         // Do not change this code. Put cleanup code in Dispose(bool disposing).
@@ -37,7 +50,7 @@ public class ModelBindingTests : IDisposable
         Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
 
         var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
-        var book = JsonConvert.DeserializeObject<SampleBook>(responseContent);
+        var book = JsonConvert.DeserializeObject<SampleBook>(responseContent, this.options);
 
         Assert.AreEqual(SampleStatus.Deleted, book?.Status);
     }
@@ -59,7 +72,7 @@ public class ModelBindingTests : IDisposable
         Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
 
         var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
-        var book = JsonConvert.DeserializeObject<SampleBook>(responseContent);
+        var book = JsonConvert.DeserializeObject<SampleBook>(responseContent, this.options);
 
         Assert.IsNull(book?.Status);
     }
@@ -82,7 +95,7 @@ public class ModelBindingTests : IDisposable
         Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
 
         var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
-        var book = JsonConvert.DeserializeObject<SampleBook>(responseContent);
+        var book = JsonConvert.DeserializeObject<SampleBook>(responseContent, this.options);
 
         Assert.IsNull(book?.Status);
     }
@@ -105,7 +118,7 @@ public class ModelBindingTests : IDisposable
         Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
 
         var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
-        var book = JsonConvert.DeserializeObject<SampleBookByStringStatus>(responseContent);
+        var book = JsonConvert.DeserializeObject<SampleBookByStringStatus>(responseContent, this.options);
 
         Assert.AreEqual(SampleStatusByString.Deleted, book?.Status);
     }

--- a/ExtendableEnums.Microsoft.AspNetCore/ExtendableEnumBinder.cs
+++ b/ExtendableEnums.Microsoft.AspNetCore/ExtendableEnumBinder.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Text.Json;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Newtonsoft.Json;
 
 namespace ExtendableEnums.Microsoft.AspNetCore;
 
@@ -10,6 +8,13 @@ namespace ExtendableEnums.Microsoft.AspNetCore;
 /// </summary>
 public class ExtendableEnumBinder : IModelBinder
 {
+    private JsonSerializerOptions jsonSerializerOptions;
+
+    public ExtendableEnumBinder(JsonSerializerOptions jsonSerializerOptions)
+    {
+        this.jsonSerializerOptions = jsonSerializerOptions;
+    }
+
     /// <summary>
     /// Attempts to bind a model.
     /// </summary>
@@ -37,7 +42,8 @@ public class ExtendableEnumBinder : IModelBinder
             return Task.CompletedTask;
         }
 
-        var result = JsonConvert.DeserializeObject($"'{valueProviderResult.FirstValue}'", bindingContext.ModelType);
+        var json = $"{{\"value\":\"{valueProviderResult.FirstValue}\"}}";
+        var result = JsonSerializer.Deserialize(json, returnType: bindingContext.ModelType, options: this.jsonSerializerOptions);
 
         bindingContext.Result = ModelBindingResult.Success(result);
 

--- a/ExtendableEnums.Microsoft.AspNetCore/ExtendableEnumModelBinderProvider.cs
+++ b/ExtendableEnums.Microsoft.AspNetCore/ExtendableEnumModelBinderProvider.cs
@@ -1,5 +1,7 @@
-﻿using System;
+﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace ExtendableEnums.Microsoft.AspNetCore;
 
@@ -22,7 +24,8 @@ public class ExtendableEnumModelBinderProvider : IModelBinderProvider
 
         if (context.Metadata.ModelType.IsExtendableEnum())
         {
-            return new ExtendableEnumBinder();
+            var options = context.Services.GetRequiredService<IOptions<JsonOptions>>().Value;
+            return new ExtendableEnumBinder(options.JsonSerializerOptions);
         }
 
         return null;

--- a/ExtendableEnums.Microsoft.AspNetCore/ExtendableEnums.Microsoft.AspNetCore.csproj
+++ b/ExtendableEnums.Microsoft.AspNetCore/ExtendableEnums.Microsoft.AspNetCore.csproj
@@ -45,5 +45,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ExtendableEnums\ExtendableEnums.csproj" />
+    <ProjectReference Include="..\ExtendableEnums.Serialization.System.Text.Json\ExtendableEnums.Serialization.System.Text.Json.csproj" />
   </ItemGroup>
 </Project>

--- a/ExtendableEnums.Serialization.Newtonsoft.Json/ExtendableEnumDictionaryJsonConverter.cs
+++ b/ExtendableEnums.Serialization.Newtonsoft.Json/ExtendableEnumDictionaryJsonConverter.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections;
-using Newtonsoft.Json;
+using ExtendableEnums;
 
-namespace ExtendableEnums.Serialization.Newtonsoft;
+namespace Newtonsoft.Json;
 
 /// <summary>
 /// Converts <see cref="ExtendableEnumDictionary{TKey, TValue}"/> objects to and from JSON.

--- a/ExtendableEnums.Serialization.Newtonsoft.Json/ExtendableEnums.Serialization.Newtonsoft.Json.csproj
+++ b/ExtendableEnums.Serialization.Newtonsoft.Json/ExtendableEnums.Serialization.Newtonsoft.Json.csproj
@@ -1,23 +1,34 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>13.0</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <ApplicationVersion>9.1</ApplicationVersion>
+    <ApplicationRevision>0</ApplicationRevision>
+    <Version>9.1</Version>
+    <PackageProjectUrl>https://github.com/kyleherzog/ExtendableEnums</PackageProjectUrl>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageTags>Enum Enumeration Extendable Class</PackageTags>
+    <RepositoryUrl>https://github.com/kyleherzog/ExtendableEnums</RepositoryUrl>
+    <Authors>Kyle Herzog</Authors>
+    <Description>A .NET Standard library that provides extendable class based enums.</Description>
+    <RootNamespace>Newtonsoft.Json</RootNamespace>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Compile Remove="Fakes\**" />
-    <EmbeddedResource Remove="Fakes\**" />
-    <None Remove="Fakes\**" />
-  </ItemGroup>
-
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="10.3.0.106239">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
@@ -26,22 +37,13 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="Text.Analyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-
   <ItemGroup>
-    <ProjectReference Include="..\ExtendableEnums.Serialization.Newtonsoft.Json\ExtendableEnums.Serialization.Newtonsoft.Json.csproj" />
-    <ProjectReference Include="..\ExtendableEnums.Serialization.System.Text.Json\ExtendableEnums.Serialization.System.Text.Json.csproj" />
     <ProjectReference Include="..\ExtendableEnums\ExtendableEnums.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="System.ComponentModel.Annotations">
-      <HintPath>..\..\..\..\Program Files\dotnet\sdk\NuGetFallbackFolder\microsoft.netcore.app\2.1.0\ref\netcoreapp2.1\System.ComponentModel.Annotations.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
 </Project>

--- a/ExtendableEnums.Serialization.Newtonsoft.Json/Internals/Methods.cs
+++ b/ExtendableEnums.Serialization.Newtonsoft.Json/Internals/Methods.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Concurrent;
 using System.Reflection;
 
-namespace ExtendableEnums.Internals;
+namespace Newtonsoft.Json.Internals;
 
 internal static class Methods
 {

--- a/ExtendableEnums.Serialization.Newtonsoft.Json/JsonSerializerSettingsExtensions.cs
+++ b/ExtendableEnums.Serialization.Newtonsoft.Json/JsonSerializerSettingsExtensions.cs
@@ -1,0 +1,29 @@
+﻿namespace Newtonsoft.Json;
+
+public static class JsonSerializerSettingsExtensions
+{
+    /// <summary>
+    /// Adds custom converters required for serializing and deserializing extendable enums
+    /// to the specified list of JSON converters.
+    /// </summary>
+    /// <example>
+    /// Example usage:
+    /// <code>
+    /// var settings = new JsonSerializerSettings
+    /// {
+    ///     Formatting = Formatting.Indented
+    /// };
+    ///
+    /// // Add the custom converters
+    /// settings.Converters.AddExtendableEnums();
+    ///
+    /// var json = JsonConvert.SerializeObject(yourObject, settings);
+    /// var obj = JsonConvert.DeserializeObject&lt;YourType&gt;(json, settings);
+    /// </code>
+    /// </example>
+    public static void AddExtendableEnums(this IList<JsonConverter> converters)
+    {
+        converters.Add(new ExtendableEnumJsonConverter());
+        converters.Add(new ExtendableEnumDictionaryJsonConverter());
+    }
+}

--- a/ExtendableEnums.Serialization.System.Text.Json/ExtendableEnumDictionaryJsonConverter.cs
+++ b/ExtendableEnums.Serialization.System.Text.Json/ExtendableEnumDictionaryJsonConverter.cs
@@ -1,7 +1,7 @@
 ﻿using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace ExtendableEnums.Serialization.SystemText;
+namespace ExtendableEnums.Serialization.System.Text.Json;
 
 /// <summary>
 /// Converts ExtendableEnum objects to and from JSON.

--- a/ExtendableEnums.Serialization.System.Text.Json/ExtendableEnumJsonConverter.cs
+++ b/ExtendableEnums.Serialization.System.Text.Json/ExtendableEnumJsonConverter.cs
@@ -1,9 +1,9 @@
 ﻿using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using ExtendableEnums.Internals;
+using ExtendableEnums.Serialization.System.Text.Json.Internals;
 
-namespace ExtendableEnums.Serialization.SystemText;
+namespace ExtendableEnums.Serialization.System.Text.Json;
 
 /// <summary>
 /// Converts ExtendableEnum objects to and from JSON.
@@ -90,10 +90,8 @@ public class ExtendableEnumJsonConverter : JsonConverterFactory
             {
                 return Activator.CreateInstance(t);
             }
-            else
-            {
-                return null;
-            }
+
+            return null;
         }
     }
 }

--- a/ExtendableEnums.Serialization.System.Text.Json/ExtendableEnums.Serialization.System.Text.Json.csproj
+++ b/ExtendableEnums.Serialization.System.Text.Json/ExtendableEnums.Serialization.System.Text.Json.csproj
@@ -1,20 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>13.0</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <ApplicationVersion>9.1</ApplicationVersion>
+    <ApplicationRevision>0</ApplicationRevision>
+    <Version>9.1</Version>
+    <PackageProjectUrl>https://github.com/kyleherzog/ExtendableEnums</PackageProjectUrl>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageTags>Enum Enumeration Extendable Class</PackageTags>
+    <RepositoryUrl>https://github.com/kyleherzog/ExtendableEnums</RepositoryUrl>
+    <Authors>Kyle Herzog</Authors>
+    <Description>A .NET Standard library that provides extendable class based enums.</Description>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Compile Remove="Fakes\**" />
-    <EmbeddedResource Remove="Fakes\**" />
-    <None Remove="Fakes\**" />
-  </ItemGroup>
-
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -26,22 +35,14 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Include="System.Text.Json" Version="9.0.0" />
     <PackageReference Include="Text.Analyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-
   <ItemGroup>
-    <ProjectReference Include="..\ExtendableEnums.Serialization.Newtonsoft.Json\ExtendableEnums.Serialization.Newtonsoft.Json.csproj" />
-    <ProjectReference Include="..\ExtendableEnums.Serialization.System.Text.Json\ExtendableEnums.Serialization.System.Text.Json.csproj" />
     <ProjectReference Include="..\ExtendableEnums\ExtendableEnums.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="System.ComponentModel.Annotations">
-      <HintPath>..\..\..\..\Program Files\dotnet\sdk\NuGetFallbackFolder\microsoft.netcore.app\2.1.0\ref\netcoreapp2.1\System.ComponentModel.Annotations.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
 </Project>

--- a/ExtendableEnums.Serialization.System.Text.Json/Internals/Methods.cs
+++ b/ExtendableEnums.Serialization.System.Text.Json/Internals/Methods.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Concurrent;
+using System.Reflection;
+
+namespace ExtendableEnums.Serialization.System.Text.Json.Internals;
+
+internal static class Methods
+{
+    private static readonly ConcurrentDictionary<Type, MethodInfo> parseValueOrCreateMethodCache = new();
+
+    internal static MethodInfo GetParseValueOrCreate(Type type)
+    {
+        return parseValueOrCreateMethodCache.GetOrAdd(type, t => t.GetMethod("ParseValueOrCreate", BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy));
+    }
+}

--- a/ExtendableEnums.Serialization.System.Text.Json/JsonSerializerOptionsExtensions.cs
+++ b/ExtendableEnums.Serialization.System.Text.Json/JsonSerializerOptionsExtensions.cs
@@ -1,0 +1,31 @@
+﻿using System.Text.Json.Serialization;
+
+namespace ExtendableEnums.Serialization.System.Text.Json;
+
+public static class JsonSerializerOptionsExtensions
+{
+    /// <summary>
+    /// Adds custom converters required for serializing and deserializing extendable enums
+    /// to the specified list of JSON converters.
+    /// </summary>
+    /// <example>
+    /// Example usage:
+    /// <code>
+    /// var options = new JsonSerializerOptions
+    /// {
+    ///     PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    /// };
+    ///
+    /// // Add the custom converters
+    /// options.Converters.AddExtendableEnums();
+    ///
+    /// var json = JsonSerializer.Serialize(yourObject, options);
+    /// var obj = JsonSerializer.Deserialize&lt;YourType&gt;(json, options);
+    /// </code>
+    /// </example>
+    public static void AddExtendableEnums(this IList<JsonConverter> converters)
+    {
+        converters.Add(new ExtendableEnumJsonConverter());
+        converters.Add(new ExtendableEnumDictionaryJsonConverter());
+    }
+}

--- a/ExtendableEnums.TestHost/Controllers/OData/SampleBooksController.cs
+++ b/ExtendableEnums.TestHost/Controllers/OData/SampleBooksController.cs
@@ -3,7 +3,6 @@ using ExtendableEnums.Testing.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.OData.Query;
 using Microsoft.AspNetCore.OData.Routing.Controllers;
-using Newtonsoft.Json;
 
 namespace ExtendableEnums.TestHost.Controllers.OData;
 
@@ -35,7 +34,7 @@ public class SampleBooksController : ODataController
     [EnableQuery]
     public IActionResult Post([FromBody] JsonElement json)
     {
-        var book = JsonConvert.DeserializeObject<SampleBook>(json.GetRawText());
+        var book = JsonSerializer.Deserialize<SampleBook>(json.GetRawText());
 
         if (book is null)
         {

--- a/ExtendableEnums.TestHost/Startup.cs
+++ b/ExtendableEnums.TestHost/Startup.cs
@@ -1,5 +1,6 @@
 ﻿using ExtendableEnums.Microsoft.AspNetCore;
 using ExtendableEnums.Microsoft.AspNetCore.OData;
+using ExtendableEnums.Serialization.System.Text.Json;
 using ExtendableEnums.Testing.Models;
 using Microsoft.AspNetCore.OData;
 using Microsoft.OData.Edm;
@@ -37,15 +38,27 @@ public class Startup
     public void ConfigureServices(IServiceCollection services)
     {
         Console.WriteLine(Configuration);
-        services.AddControllers().AddOData(opt =>
-        {
-            opt.Select().Expand().Filter().OrderBy().SetMaxTop(100).Count();
-            opt.AddRouteComponents("odata", GetEdmModel());
-        });
-        services.AddMvc(options =>
-        {
-            options.UseExtendableEnumModelBinding();
-        });
+
+        services.AddControllers()
+            .AddOData(opt =>
+            {
+                opt.Select().Expand().Filter().OrderBy().SetMaxTop(100).Count();
+                opt.AddRouteComponents("odata", GetEdmModel());
+            })
+            .AddJsonOptions(options =>
+            {
+                options.JsonSerializerOptions.Converters.AddExtendableEnums();
+            });
+
+        services
+            .AddMvc(options =>
+            {
+                options.UseExtendableEnumModelBinding();
+            })
+            .AddJsonOptions(options =>
+            {
+                options.JsonSerializerOptions.Converters.AddExtendableEnums();
+            });
     }
 
     private static IEdmModel GetEdmModel()

--- a/ExtendableEnums.Testing.Models/SampleStatus.cs
+++ b/ExtendableEnums.Testing.Models/SampleStatus.cs
@@ -1,9 +1,10 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
-using ExtendableEnums.Serialization.SystemText;
+using ExtendableEnums.Serialization.System.Text.Json;
 
 namespace ExtendableEnums.Testing.Models;
 
 [System.Text.Json.Serialization.JsonConverter(typeof(ExtendableEnumJsonConverter))]
+[Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.ExtendableEnumJsonConverter))]
 public class SampleStatus : ExtendableEnums.ExtendableEnum<SampleStatus>
 {
     public static readonly SampleStatus Active = new(1, nameof(Active), "ACT");

--- a/ExtendableEnums.Testing.Models/SampleStatusByString.cs
+++ b/ExtendableEnums.Testing.Models/SampleStatusByString.cs
@@ -1,5 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
-using ExtendableEnums.Serialization.SystemText;
+using ExtendableEnums.Serialization.System.Text.Json;
 
 namespace ExtendableEnums.Testing.Models;
 

--- a/ExtendableEnums.Testing/TestingHost.cs
+++ b/ExtendableEnums.Testing/TestingHost.cs
@@ -132,7 +132,6 @@ public class TestingHost : IDisposable
                 .UseContentRoot(GetSolutionRelativeContentRoot(SolutionRelativeRootPath))
                 .UseStartup(StartupType);
             })
-
             .Build();
 
         host.Start();

--- a/ExtendableEnums.UnitTests/ExtendableEnumDictionaryTests/DeserializeShould.cs
+++ b/ExtendableEnums.UnitTests/ExtendableEnumDictionaryTests/DeserializeShould.cs
@@ -8,6 +8,19 @@ namespace ExtendableEnums.UnitTests.ExtendableEnumDictionaryTests;
 [TestClass]
 public class DeserializeShould
 {
+    private JsonSerializerSettings options = new();
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        var options = new JsonSerializerSettings
+        {
+            Formatting = Formatting.Indented
+        };
+        options.Converters.AddExtendableEnums();
+        this.options = options;
+    }
+
     [TestMethod]
     public void DeserializeGivenValidSerialized()
     {
@@ -19,7 +32,7 @@ public class DeserializeShould
             { SampleStatus.Deleted, nameof(SampleStatus.Deleted) },
         };
 
-        var result = JsonConvert.DeserializeObject<ExtendableEnumDictionary<SampleStatus, string>>(serialized);
+        var result = JsonConvert.DeserializeObject<ExtendableEnumDictionary<SampleStatus, string>>(serialized, this.options);
 
         result.Should().BeEquivalentTo(expected);
     }
@@ -35,7 +48,7 @@ public class DeserializeShould
             { SampleStatusByString.Deleted, nameof(SampleStatusByString.Deleted) },
         };
 
-        var result = JsonConvert.DeserializeObject<ExtendableEnumDictionary<SampleStatusByString, string>>(serialized);
+        var result = JsonConvert.DeserializeObject<ExtendableEnumDictionary<SampleStatusByString, string>>(serialized, this.options);
 
         result.Should().BeEquivalentTo(expected);
     }
@@ -52,7 +65,7 @@ public class DeserializeShould
             { SampleStatusByString.Deleted, nameof(SampleStatusByString.Deleted) },
         };
 
-        var result = JsonConvert.DeserializeObject<ExtendableEnumDictionary<SampleStatusByString, string>>(serialized);
+        var result = JsonConvert.DeserializeObject<ExtendableEnumDictionary<SampleStatusByString, string>>(serialized, this.options);
 
         result.Should().BeEquivalentTo(expected);
     }
@@ -69,7 +82,7 @@ public class DeserializeShould
             { SampleStatus.Deleted, nameof(SampleStatus.Deleted) },
         };
 
-        var result = JsonConvert.DeserializeObject<ExtendableEnumDictionary<SampleStatus, string>>(serialized);
+        var result = JsonConvert.DeserializeObject<ExtendableEnumDictionary<SampleStatus, string>>(serialized, this.options);
 
         result.Should().BeEquivalentTo(expected);
     }

--- a/ExtendableEnums.UnitTests/ExtendableEnumDictionaryTests/SerializeShould.cs
+++ b/ExtendableEnums.UnitTests/ExtendableEnumDictionaryTests/SerializeShould.cs
@@ -7,6 +7,19 @@ namespace ExtendableEnums.UnitTests.ExtendableEnumDictionaryTests;
 [TestClass]
 public class SerializeShould
 {
+    private JsonSerializerSettings options = new();
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        var options = new JsonSerializerSettings
+        {
+            Formatting = Formatting.None
+        };
+        options.Converters.AddExtendableEnums();
+        this.options = options;
+    }
+
     [TestMethod]
     public void SerializeKeyAsValueOnlyGivenIntValue()
     {
@@ -16,7 +29,7 @@ public class SerializeShould
             { SampleStatus.Deleted, nameof(SampleStatus.Deleted) },
         };
 
-        var serialized = JsonConvert.SerializeObject(items);
+        var serialized = JsonConvert.SerializeObject(items, this.options);
         Assert.AreEqual("{\"1\":\"Active\",\"2\":\"Deleted\"}", serialized);
     }
 
@@ -29,7 +42,7 @@ public class SerializeShould
             { SampleStatusByString.Deleted, nameof(SampleStatusByString.Deleted) },
         };
 
-        var serialized = JsonConvert.SerializeObject(items);
+        var serialized = JsonConvert.SerializeObject(items, this.options);
         Assert.AreEqual("{\"B\":\"Active\",\"C\":\"Deleted\"}", serialized);
     }
 }

--- a/ExtendableEnums.UnitTests/ExtendableEnumTests/NewsonsoftSerializationShould.cs
+++ b/ExtendableEnums.UnitTests/ExtendableEnumTests/NewsonsoftSerializationShould.cs
@@ -7,46 +7,59 @@ namespace ExtendableEnums.UnitTests.ExpandableEnumerationTests;
 [TestClass]
 public class NewsonsoftSerializationShould
 {
+    private JsonSerializerSettings options = new();
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        var options = new JsonSerializerSettings
+        {
+            Formatting = Formatting.Indented
+        };
+        options.Converters.AddExtendableEnums();
+        this.options = options;
+    }
+
     [TestMethod]
     public void DeserializeFromNull()
     {
-        var nullSerialized = JsonConvert.SerializeObject(null);
-        var status = JsonConvert.DeserializeObject<SampleStatus>(nullSerialized);
+        var nullSerialized = JsonConvert.SerializeObject(null, this.options);
+        var status = JsonConvert.DeserializeObject<SampleStatus>(nullSerialized, this.options);
         Assert.IsNull(status);
     }
 
     [TestMethod]
     public void DeserializeFromObjectGivenNumericValuePripertyNotDeclaredInPrimaryType()
     {
-        var status = JsonConvert.DeserializeObject<SampleStatus>($"{{\"value\" : \"{SampleStatusDeclared.Pending.Value}\"}}");
+        var status = JsonConvert.DeserializeObject<SampleStatus>($"{{\"value\" : \"{SampleStatusDeclared.Pending.Value}\"}}", this.options);
         Assert.AreEqual(SampleStatusDeclared.Pending, status);
     }
 
     [TestMethod]
     public void DeserializeFromObjectWithNoValuePropertyToDefaultValue()
     {
-        var status = JsonConvert.DeserializeObject<SampleStatus>($"{{\"id\" : \"{SampleStatus.Inactive.Value}\"}}");
+        var status = JsonConvert.DeserializeObject<SampleStatus>($"{{\"id\" : \"{SampleStatus.Inactive.Value}\"}}", this.options);
         Assert.AreEqual(SampleStatus.Unknown, status);
     }
 
     [TestMethod]
     public void DeserializeFromObjectWithNumericValueProperty()
     {
-        var status = JsonConvert.DeserializeObject<SampleStatus>($"{{\"value\" : {SampleStatus.Inactive.Value}}}");
+        var status = JsonConvert.DeserializeObject<SampleStatus>($"{{\"value\" : {SampleStatus.Inactive.Value}}}", this.options);
         Assert.AreEqual(SampleStatus.Inactive, status);
     }
 
     [TestMethod]
     public void DeserializeFromObjectWithStringValueProperty()
     {
-        var status = JsonConvert.DeserializeObject<SampleStatusByString>($"{{\"value\" : \"{SampleStatusByString.Inactive.Value}\"}}");
+        var status = JsonConvert.DeserializeObject<SampleStatusByString>($"{{\"value\" : \"{SampleStatusByString.Inactive.Value}\"}}", this.options);
         Assert.AreEqual(SampleStatusByString.Inactive, status);
     }
 
     [TestMethod]
     public void DeserializeFromObjectNotDefined()
     {
-        var status = JsonConvert.DeserializeObject<SampleStatus>("{\"value\" : -123}");
+        var status = JsonConvert.DeserializeObject<SampleStatus>("{\"value\" : -123}", this.options);
         Assert.AreEqual(-123, status?.Value);
     }
 
@@ -58,14 +71,14 @@ public class NewsonsoftSerializationShould
         dictionary.Add(keyStatus, "test value");
         var serialized = JsonConvert.SerializeObject(dictionary);
         Console.WriteLine(serialized);
-        var deserialized = JsonConvert.DeserializeObject<Dictionary<SampleStatus, string>>(serialized);
+        var deserialized = JsonConvert.DeserializeObject<Dictionary<SampleStatus, string>>(serialized, this.options);
         Assert.AreEqual(dictionary[keyStatus], deserialized?[keyStatus]);
     }
 
     [TestMethod]
     public void DeserializeFromTheValueOnly()
     {
-        var status = JsonConvert.DeserializeObject<SampleStatus>($"{SampleStatus.Inactive.Value}");
+        var status = JsonConvert.DeserializeObject<SampleStatus>($"{SampleStatus.Inactive.Value}", this.options);
         Assert.AreEqual(SampleStatus.Inactive, status);
     }
 
@@ -73,7 +86,7 @@ public class NewsonsoftSerializationShould
     public void SerializeTheValueOnly()
     {
         var status = SampleStatus.Active;
-        var serialized = JsonConvert.SerializeObject(status);
+        var serialized = JsonConvert.SerializeObject(status, this.options);
 
         Assert.AreEqual($"{status.Value}", serialized);
     }
@@ -82,7 +95,7 @@ public class NewsonsoftSerializationShould
     public void SerializeToNull()
     {
         SampleStatus? status = null;
-        var serialized = JsonConvert.SerializeObject(status);
+        var serialized = JsonConvert.SerializeObject(status, this.options);
         Assert.AreEqual("null", serialized);
     }
 }

--- a/ExtendableEnums.UnitTests/ExtendableEnumTests/SystemTextSerializationShould.cs
+++ b/ExtendableEnums.UnitTests/ExtendableEnumTests/SystemTextSerializationShould.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json;
+using ExtendableEnums.Serialization.System.Text.Json;
 using ExtendableEnums.Testing.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -7,46 +8,59 @@ namespace ExtendableEnums.UnitTests.ExtendableEnumerationTests;
 [TestClass]
 public class SystemTextSerializationShould
 {
+    private JsonSerializerOptions options = new();
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        var options = new JsonSerializerOptions()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+        options.Converters.AddExtendableEnums();
+        this.options = options;
+    }
+
     [TestMethod]
     public void DeserializeFromNull()
     {
-        var nullSerialized = JsonSerializer.Serialize<SampleStatus?>(null);
-        var status = JsonSerializer.Deserialize<SampleStatus?>(nullSerialized);
+        var nullSerialized = JsonSerializer.Serialize<SampleStatus?>(null, this.options);
+        var status = JsonSerializer.Deserialize<SampleStatus?>(nullSerialized, this.options);
         Assert.IsNull(status);
     }
 
     [TestMethod]
     public void DeserializeFromObjectGivenNumericValuePripertyNotDeclaredInPrimaryType()
     {
-        var status = JsonSerializer.Deserialize<SampleStatus>($"{{\"value\" : \"{SampleStatusDeclared.Pending.Value}\"}}");
+        var status = JsonSerializer.Deserialize<SampleStatus>($"{{\"value\" : \"{SampleStatusDeclared.Pending.Value}\"}}", this.options);
         Assert.AreEqual(SampleStatusDeclared.Pending, status);
     }
 
     [TestMethod]
     public void DeserializeFromObjectWithNoValuePropertyToDefaultValue()
     {
-        var status = JsonSerializer.Deserialize<SampleStatus>($"{{\"id\" : \"{SampleStatus.Inactive.Value}\"}}");
+        var status = JsonSerializer.Deserialize<SampleStatus>($"{{\"id\" : \"{SampleStatus.Inactive.Value}\"}}", this.options);
         Assert.AreEqual(SampleStatus.Unknown, status);
     }
 
     [TestMethod]
     public void DeserializeFromObjectWithNumericValueProperty()
     {
-        var status = JsonSerializer.Deserialize<SampleStatus>($"{{\"value\" : {SampleStatus.Inactive.Value}}}");
+        var status = JsonSerializer.Deserialize<SampleStatus>($"{{\"value\" : {SampleStatus.Inactive.Value}}}", this.options);
         Assert.AreEqual(SampleStatus.Inactive, status);
     }
 
     [TestMethod]
     public void DeserializeFromObjectWithStringValueProperty()
     {
-        var status = JsonSerializer.Deserialize<SampleStatusByString>($"{{\"value\" : \"{SampleStatusByString.Inactive.Value}\"}}");
+        var status = JsonSerializer.Deserialize<SampleStatusByString>($"{{\"value\" : \"{SampleStatusByString.Inactive.Value}\"}}", this.options);
         Assert.AreEqual(SampleStatusByString.Inactive, status);
     }
 
     [TestMethod]
     public void DeserializeFromObjectNotDefined()
     {
-        var status = JsonSerializer.Deserialize<SampleStatus>("{\"value\" : -123}");
+        var status = JsonSerializer.Deserialize<SampleStatus>("{\"value\" : -123}", this.options);
         Assert.AreEqual(-123, status?.Value);
     }
 
@@ -56,16 +70,16 @@ public class SystemTextSerializationShould
         var dictionary = new ExtendableEnumDictionary<SampleStatus, string>();
         var keyStatus = SampleStatus.Discontinued;
         dictionary.Add(keyStatus, "test value");
-        var serialized = JsonSerializer.Serialize(dictionary);
+        var serialized = JsonSerializer.Serialize(dictionary, this.options);
         Console.WriteLine(serialized);
-        var deserialized = JsonSerializer.Deserialize<ExtendableEnumDictionary<SampleStatus, string>>(serialized);
+        var deserialized = JsonSerializer.Deserialize<ExtendableEnumDictionary<SampleStatus, string>>(serialized, this.options);
         Assert.AreEqual(dictionary[keyStatus], deserialized?[keyStatus]);
     }
 
     [TestMethod]
     public void DeserializeFromTheValueOnly()
     {
-        var status = JsonSerializer.Deserialize<SampleStatus>($"{SampleStatus.Inactive.Value}");
+        var status = JsonSerializer.Deserialize<SampleStatus>($"{SampleStatus.Inactive.Value}", this.options);
         Assert.AreEqual(SampleStatus.Inactive, status);
     }
 
@@ -73,7 +87,7 @@ public class SystemTextSerializationShould
     public void SerializeTheValueOnly()
     {
         var status = SampleStatus.Active;
-        var serialized = JsonSerializer.Serialize(status);
+        var serialized = JsonSerializer.Serialize(status, this.options);
 
         Assert.AreEqual($"{status.Value}", serialized);
     }
@@ -82,7 +96,7 @@ public class SystemTextSerializationShould
     public void SerializeToNull()
     {
         SampleStatus? status = null;
-        var serialized = JsonSerializer.Serialize(status);
+        var serialized = JsonSerializer.Serialize(status, this.options);
         Assert.AreEqual("null", serialized);
     }
 }

--- a/ExtendableEnums.UnitTests/ExtendableEnums.UnitTests.csproj
+++ b/ExtendableEnums.UnitTests/ExtendableEnums.UnitTests.csproj
@@ -33,6 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\ExtendableEnums.Serialization.Newtonsoft.Json\ExtendableEnums.Serialization.Newtonsoft.Json.csproj" />
     <ProjectReference Include="..\ExtendableEnums.Testing.Models\ExtendableEnums.Testing.Models.csproj" />
   </ItemGroup>
 

--- a/ExtendableEnums.sln
+++ b/ExtendableEnums.sln
@@ -41,6 +41,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExtendableEnums.EntityFrame
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExtendableEnums.Demo.Wasm", "ExtendableEnums.Demo.Wasm\ExtendableEnums.Demo.Wasm.csproj", "{D552BEE7-F8FD-4967-AFBF-BA0E054AD6CA}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExtendableEnums.Serialization.Newtonsoft.Json", "ExtendableEnums.Serialization.Newtonsoft.Json\ExtendableEnums.Serialization.Newtonsoft.Json.csproj", "{19AC125D-474C-4C01-B36E-3CE6EE1E3864}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExtendableEnums.Serialization.System.Text.Json", "ExtendableEnums.Serialization.System.Text.Json\ExtendableEnums.Serialization.System.Text.Json.csproj", "{4AECE989-A952-4295-841F-3A40583FBE68}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -107,6 +111,14 @@ Global
 		{D552BEE7-F8FD-4967-AFBF-BA0E054AD6CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D552BEE7-F8FD-4967-AFBF-BA0E054AD6CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D552BEE7-F8FD-4967-AFBF-BA0E054AD6CA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{19AC125D-474C-4C01-B36E-3CE6EE1E3864}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{19AC125D-474C-4C01-B36E-3CE6EE1E3864}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{19AC125D-474C-4C01-B36E-3CE6EE1E3864}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{19AC125D-474C-4C01-B36E-3CE6EE1E3864}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4AECE989-A952-4295-841F-3A40583FBE68}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4AECE989-A952-4295-841F-3A40583FBE68}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4AECE989-A952-4295-841F-3A40583FBE68}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4AECE989-A952-4295-841F-3A40583FBE68}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ExtendableEnums/ExtendableEnum.cs
+++ b/ExtendableEnums/ExtendableEnum.cs
@@ -12,7 +12,6 @@ public abstract class ExtendableEnum<TEnumeration> : ExtendableEnumBase<TEnumera
     /// </summary>
     /// <param name="value">The unique value that represents this enumeration value.</param>
     /// <param name="displayName">The <see cref="string"/> value that represents its display name.</param>
-    [System.Text.Json.Serialization.JsonConstructor]
     protected ExtendableEnum(int value, string displayName)
         : base(value, displayName)
     {

--- a/ExtendableEnums/ExtendableEnumBase.cs
+++ b/ExtendableEnums/ExtendableEnumBase.cs
@@ -1,8 +1,6 @@
 ﻿using System.ComponentModel;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Reflection;
-using ExtendableEnums.Serialization.Newtonsoft;
-using Newtonsoft.Json;
 
 namespace ExtendableEnums;
 
@@ -11,7 +9,6 @@ namespace ExtendableEnums;
 /// </summary>
 /// <typeparam name="TEnumeration">The <see cref="Type"/> of this enumeration (itself).</typeparam>
 /// <typeparam name="TValue">The <see cref="Type"/> of the value property.</typeparam>
-[JsonConverter(typeof(ExtendableEnumJsonConverter))]
 [TypeConverter(typeof(ExtendableEnumTypeConverter))]
 public abstract class ExtendableEnumBase<TEnumeration, TValue> : IExtendableEnum<TValue>, IComparable<TEnumeration>, IComparable, IEquatable<TEnumeration>
         where TEnumeration : ExtendableEnumBase<TEnumeration, TValue>

--- a/ExtendableEnums/ExtendableEnumDictionary.cs
+++ b/ExtendableEnums/ExtendableEnumDictionary.cs
@@ -1,7 +1,5 @@
 ﻿using System.Diagnostics;
 using System.Runtime.Serialization;
-using ExtendableEnums.Serialization.Newtonsoft;
-using Newtonsoft.Json;
 
 namespace ExtendableEnums;
 
@@ -11,8 +9,6 @@ namespace ExtendableEnums;
 /// </summary>
 /// <typeparam name="TKey">The type of the key.</typeparam>
 /// <typeparam name="TValue">The type of the value.</typeparam>
-[System.Text.Json.Serialization.JsonConverter(typeof(ExtendableEnums.Serialization.SystemText.ExtendableEnumDictionaryJsonConverter))]
-[JsonConverter(typeof(ExtendableEnumDictionaryJsonConverter))]
 [Serializable]
 public class ExtendableEnumDictionary<TKey, TValue> : Dictionary<TKey, TValue>
     where TKey : IExtendableEnum

--- a/ExtendableEnums/ExtendableEnums.csproj
+++ b/ExtendableEnums/ExtendableEnums.csproj
@@ -27,7 +27,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="10.3.0.106239">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
@@ -37,7 +36,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageReference Include="System.Text.Json" Version="9.0.0" />
     <PackageReference Include="Text.Analyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/ExtendableEnums/TypeExtensions.cs
+++ b/ExtendableEnums/TypeExtensions.cs
@@ -47,7 +47,7 @@ public static class TypeExtensions
         return IsTypeDerivedFromGenericType(type, typeof(ExtendableEnumDictionary<,>));
     }
 
-    internal static Type[] GetExtendableEnumArgs(this Type type)
+    public static Type[] GetExtendableEnumArgs(this Type type)
     {
         if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ExtendableEnumBase<,>))
         {
@@ -55,12 +55,12 @@ public static class TypeExtensions
             return args;
         }
 
-        if (type.BaseType != typeof(object))
+        if (type.BaseType is { } baseType && baseType != typeof(object))
         {
-            return GetExtendableEnumArgs(type.BaseType);
+            return GetExtendableEnumArgs(baseType);
         }
 
-        return Array.Empty<Type>();
+        return [];
     }
 
     private static bool IsTypeDerivedFromGenericType(Type typeToCheck, Type genericType)
@@ -69,17 +69,17 @@ public static class TypeExtensions
         {
             return false;
         }
-        else if (typeToCheck is null)
+
+        if (typeToCheck is null)
         {
             return false;
         }
-        else if (typeToCheck.IsGenericType && typeToCheck.GetGenericTypeDefinition() == genericType)
+
+        if (typeToCheck.IsGenericType && typeToCheck.GetGenericTypeDefinition() == genericType)
         {
             return true;
         }
-        else
-        {
-            return IsTypeDerivedFromGenericType(typeToCheck.BaseType, genericType);
-        }
+
+        return IsTypeDerivedFromGenericType(typeToCheck.BaseType, genericType);
     }
 }


### PR DESCRIPTION
- Moving code that is dependent on `System.Text.Json` and `Newtonsoft.Json` to dedicated libraries
- Switching from `Newtonsoft.Json` to `System.Text.Json` for ASP.NET binder
- Fixing all unit tests

**Open issues**

- Update documentation. 
  - Because the serialization attributes are now missing, a dedicated registration for the JsonConverters is required
  - Additonal NuGet packages must be added when serialization is required
- Update version number because of breaking change